### PR TITLE
Initial replacement of ImageIO with Bio-Formats for in-memory tile writing

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
@@ -169,7 +169,13 @@ public class TileRequestHandler {
         Location.mapFile(id, handle);
         writer.setId(id);
         writer.saveBytes(0, tileBuffer.array());
-        return handle.getBytes();
+
+        // trim byte array to written length (not backing array length)
+        ByteBuffer bytes = handle.getByteBuffer();
+        byte[] file = new byte[(int) handle.length()];
+        bytes.position(0);
+        bytes.get(file);
+        return file;
       }
       finally {
         Location.mapFile(id, null);

--- a/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
@@ -143,13 +143,15 @@ public class TileRequestHandler {
       metadata.setImageID("Image:0", 0);
       metadata.setPixelsID("Pixels:0", 0);
       metadata.setChannelID("Channel:0:0", 0, 0);
+      metadata.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
+      metadata.setPixelsBigEndian(true, 0);
       metadata.setPixelsSizeX(new PositiveInteger(tileCtx.region.getWidth()), 0);
       metadata.setPixelsSizeY(new PositiveInteger(tileCtx.region.getHeight()), 0);
       metadata.setPixelsSizeZ(new PositiveInteger(1), 0);
       metadata.setPixelsSizeC(new PositiveInteger(1), 0);
       metadata.setPixelsSizeT(new PositiveInteger(1), 0);
       metadata.setPixelsDimensionOrder(DimensionOrder.XYCZT, 0);
-      metadata.setPixelsType(PixelType.fromString(pixels.getPixelsType().getValue().toString()), 0);
+      metadata.setPixelsType(PixelType.fromString(pixels.getPixelsType().getValue().getValue()), 0);
       return metadata;
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
@@ -139,20 +139,20 @@ public class TileRequestHandler {
      * Construct a minimal IMetadata instance representing the current tile.
      */
     private IMetadata createMetadata(Pixels pixels) throws EnumerationException {
-      IMetadata metadata = MetadataTools.createOMEXMLMetadata();
-      metadata.setImageID("Image:0", 0);
-      metadata.setPixelsID("Pixels:0", 0);
-      metadata.setChannelID("Channel:0:0", 0, 0);
-      metadata.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
-      metadata.setPixelsBigEndian(true, 0);
-      metadata.setPixelsSizeX(new PositiveInteger(tileCtx.region.getWidth()), 0);
-      metadata.setPixelsSizeY(new PositiveInteger(tileCtx.region.getHeight()), 0);
-      metadata.setPixelsSizeZ(new PositiveInteger(1), 0);
-      metadata.setPixelsSizeC(new PositiveInteger(1), 0);
-      metadata.setPixelsSizeT(new PositiveInteger(1), 0);
-      metadata.setPixelsDimensionOrder(DimensionOrder.XYCZT, 0);
-      metadata.setPixelsType(PixelType.fromString(pixels.getPixelsType().getValue().getValue()), 0);
-      return metadata;
+        IMetadata metadata = MetadataTools.createOMEXMLMetadata();
+        metadata.setImageID("Image:0", 0);
+        metadata.setPixelsID("Pixels:0", 0);
+        metadata.setChannelID("Channel:0:0", 0, 0);
+        metadata.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
+        metadata.setPixelsBigEndian(true, 0);
+        metadata.setPixelsSizeX(new PositiveInteger(tileCtx.region.getWidth()), 0);
+        metadata.setPixelsSizeY(new PositiveInteger(tileCtx.region.getHeight()), 0);
+        metadata.setPixelsSizeZ(new PositiveInteger(1), 0);
+        metadata.setPixelsSizeC(new PositiveInteger(1), 0);
+        metadata.setPixelsSizeT(new PositiveInteger(1), 0);
+        metadata.setPixelsDimensionOrder(DimensionOrder.XYCZT, 0);
+        metadata.setPixelsType(PixelType.fromString(pixels.getPixelsType().getValue().getValue()), 0);
+        return metadata;
     }
 
     /**
@@ -160,27 +160,25 @@ public class TileRequestHandler {
      * The output format is determined by the extension (e.g. "png", "tif")
      */
     private byte[] writeImage(String extension, ByteBuffer tileBuffer, IMetadata metadata)
-      throws FormatException, IOException
-    {
-      String id = System.currentTimeMillis() + "." + extension;
-      ByteArrayHandle handle = new ByteArrayHandle();
-      try (ImageWriter writer = new ImageWriter()) {
-        writer.setMetadataRetrieve(metadata);
-        Location.mapFile(id, handle);
-        writer.setId(id);
-        writer.saveBytes(0, tileBuffer.array());
+            throws FormatException, IOException {
+        String id = System.currentTimeMillis() + "." + extension;
+        ByteArrayHandle handle = new ByteArrayHandle();
+        try (ImageWriter writer = new ImageWriter()) {
+            writer.setMetadataRetrieve(metadata);
+            Location.mapFile(id, handle);
+            writer.setId(id);
+            writer.saveBytes(0, tileBuffer.array());
 
-        // trim byte array to written length (not backing array length)
-        ByteBuffer bytes = handle.getByteBuffer();
-        byte[] file = new byte[(int) handle.length()];
-        bytes.position(0);
-        bytes.get(file);
-        return file;
-      }
-      finally {
-        Location.mapFile(id, null);
-        handle.close();
-      }
+            // trim byte array to written length (not backing array length)
+            ByteBuffer bytes = handle.getByteBuffer();
+            byte[] file = new byte[(int) handle.length()];
+            bytes.position(0);
+            bytes.get(file);
+            return file;
+        } finally {
+            Location.mapFile(id, null);
+            handle.close();
+        }
     }
 
     protected PixelBuffer getPixelBuffer(Pixels pixels)


### PR DESCRIPTION
Uses Bio-Formats' in-memory writing feature as described in https://docs.openmicroscopy.org/bio-formats/5.8.2/developers/in-memory.html#writing-to-memory

This has been tested to the extent that ```curl http://localhost:8080/tile/...``` against an SVS file imported into a local OMERO server returns valid TIFF and PNG files.  For both formats, the resulting files can be read by ImageMagick and Bio-Formats, and were confirmed to be written by Bio-Formats.

I haven't done any real performance test yet; to get realistic numbers it would be better to do this on an existing system instead of what I have set up locally on a VM.