### PR TITLE
 Ensure that anonymous cipher suites are enabled in the JRE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ configurations.all {
 
 dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.7'
-    compile ('com.glencoesoftware.omero:omero-ms-core:0.4.0') {
+    compile ('com.glencoesoftware.omero:omero-ms-core:0.4.1') {
         exclude group: 'org.testng', module: 'testng'
     }
     compile 'io.vertx:vertx-config:3.5.3'

--- a/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/PixelBufferMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/PixelBufferMicroserviceVerticle.java
@@ -67,6 +67,10 @@ public class PixelBufferMicroserviceVerticle extends AbstractVerticle {
     /** OMERO server Spring application context. */
     private ApplicationContext context;
 
+    static {
+        com.glencoesoftware.omero.ms.core.SSLUtils.fixDisabledAlgorithms();
+    }
+
     /**
      * Entry point method which starts the server event loop and initializes
      * our current OMERO.web session store.


### PR DESCRIPTION
OMERO 5.5 will no longer require this. See:
 * glencoesoftware/omero-ms-image-region#34
 * glencoesoftware/omero-ms-thumbnail#11
 * openmicroscopy/openmicroscopy#5949