### PR TITLE
Configuration review

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ What follows is a snippet which can be placed in your nginx configuration,
 image region microservice server endpoint::
 
     upstream pixel_buffer_backend {
-        server 127.0.0.1:8080 fail_timeout=0 max_fails=0;
+        server 127.0.0.1:8082 fail_timeout=0 max_fails=0;
     }
 
     ...
@@ -135,7 +135,7 @@ value. This is the OMERO.web session key.
 1. Run single or multiple tile tests using `curl`::
 
         curl -H 'Cookie: sessionid=<omero_web_session_key>' \
-            http://localhost:8080/tile/<image_id>/<z>/<c>/<t>?x=<x>&y=<y>&w=<w>&h=<h>&format=<format>&filename=<filename>
+            http://localhost:8082/tile/<image_id>/<z>/<c>/<t>?x=<x>&y=<y>&w=<w>&h=<h>&format=<format>&filename=<filename>
 
 Valid formats, if missing the format will be raw pixels, include:
 

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -1,5 +1,5 @@
 # The port that the microservice will listen on
-port: 8080
+port: 8082
 # OMERO server that the microservice will communicate with (as a client)
 omero:
     host: "localhost"

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -31,7 +31,7 @@ session-store:
 
 # Configuration for zipkin http tracing
 http-tracing:
-    enabled: true
+    enabled: false
     zipkin-url: "http://localhost:9411/api/v2/spans"
 
 # Enable JMX Prometheus Metrics

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -13,17 +13,20 @@ omero.server:
     omero.db.user: "omero"
     omero.db.pass: "omero"
     # OMERO_HOME/lib/scripts
-    omero.script_repo_root: "/opt/omero/lib/scripts"
+    omero.script_repo_root: "/opt/omero/OMERO.current/lib/scripts"
 # Information about the session store.
 session-store:
     #type is either "postgres" or "redis"
-    type: "postgres"
+    type: "redis"
     #synchronicity is either "sync" or "async"
     synchronicity: "async"
     #uri for either postgres db or redis
     # * https://jdbc.postgresql.org/documentation/80/connect.html
     # * https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details
-    uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
+    # uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
+    # For Redis in protected mode
+    uri: "redis://:@localhost:6379/1"
+    # For Redis in non-protected mode
     # uri: "redis://:password@localhost:6379/1"
 
 # Configuration for zipkin http tracing

--- a/src/dist/conf/logback.xml
+++ b/src/dist/conf/logback.xml
@@ -8,9 +8,11 @@
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${application.home:-.}/logs/omero-ms.log</file>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${application.home:-.}/logs/omero-ms.%d{yyyy-MM-dd}.log</fileNamePattern>
-      </rollingPolicy>
+            <fileNamePattern>${application.home:-.}/logs/omero-ms.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+    </rollingPolicy>
     <encoder>
       <pattern>%date [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
@@ -21,6 +23,6 @@
   <logger name="loci.formats.Memoizer" level="INFO"/><!-- Bio-Formats memoizer -->
 
   <root level="info">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILE" />
   </root>
 </configuration>


### PR DESCRIPTION
See https://github.com/glencoesoftware/omero-ms-image-region/pull/123 and https://github.com/glencoesoftware/omero-ms-thumbnail/pull/22

- set the default port to 8082
- set redis as the default session backend
- disable http-tracing by default
- add production logback configuration