### PR TITLE
Add support for OME-Zarr hosted on AWS S3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ configurations.all {
     exclude group: 'gnu.getopt'
     exclude group: 'net.sf.ehcache'
     exclude group: 'org.apache.commons'
-    exclude group: 'org.apache.httpcomponents'
     exclude group: 'org.apache.pdfbox'
     exclude group: 'org.apache.xmlgraphics'
     exclude group: 'org.ini4j'

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -12,6 +12,7 @@ omero.server:
     omero.db.port: "5432"
     omero.db.user: "omero"
     omero.db.pass: "omero"
+    omero.pixeldata.pixels_service: "ZarrPixelsService"
     # OMERO_HOME/lib/scripts
     omero.script_repo_root: "/opt/omero/OMERO.current/lib/scripts"
 # Information about the session store.

--- a/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/pixelbuffer/TileRequestHandler.java
@@ -228,9 +228,11 @@ public class TileRequestHandler {
         try {
             return (Pixels) client.getSession().getQueryService().findByQuery(
                 "SELECT p FROM Pixels as p " +
-                "JOIN FETCH p.image " +
+                "JOIN FETCH p.image as i " +
+                "JOIN FETCH i.format " +
+                "LEFT OUTER JOIN FETCH i.details.externalInfo " +
                 "JOIN FETCH p.pixelsType " +
-                "WHERE p.image.id = :id",
+                "WHERE i.id = :id",
                 params, ctx
             );
         } finally {

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -46,20 +46,9 @@
 
   <bean id="metrics" class="ome.system.metrics.NullMetrics"/>
   
-  <bean name="/OMERO/Pixels" class="com.glencoesoftware.omero.ms.image.region.PixelsService"
-        parent="filesystem">
-    <!-- index=0 "path" comes from parent -->
-    <constructor-arg index="2" value="${omero.pixeldata.memoizer.dir}"/>
-    <constructor-arg index="3" ref="MemoizerWait"/>
-    <constructor-arg index="4" ref="omeroFilePathResolver"/>
-    <constructor-arg index="5" ref="backOff"/>
-    <constructor-arg index="6" ref="tileSizes"/>
-    <constructor-arg index="7" ><null /></constructor-arg>
-    <constructor-arg index="8" value="${omero.pixeldata.zarr_cache_size:500}" />
-    <constructor-arg index="9" value="${omero.pixeldata.max_plane_width:3192}" />
-    <constructor-arg index="10" value="${omero.pixeldata.max_plane_height:3192}" />
-    <property name="metrics" ref="metrics"/>
-  </bean>
+  <bean id="internal-ome.api.IQuery" class="com.glencoesoftware.omero.ms.core.NoopQueryImpl"/>
+
+  <alias name="${omero.pixeldata.pixels_service:ZarrPixelsService}" alias="/OMERO/Pixels"/>
 
   <bean id="omero-ms-pixel-buffer-verticle"
         class="com.glencoesoftware.omero.ms.pixelbuffer.PixelBufferVerticle"


### PR DESCRIPTION
This makes a few functional changes on top of #23 allowing the pixel-buffer micro-service to use the `ZarrPixelBuffer` and access raw data of Zarr and non-Zarr images.

The following changes have been made:

- the `/OMERO/Pixels` bean pointing to the removed `com.glencoesoftware.omero.ms.image.region.PixelsService` implementation and replace by an alias pointing at `ZarrPixelsService` by default
- a configuration property is added allowing this pixelservice to be runtime configured - see also https://github.com/glencoesoftware/omero-ms-image-region/pull/142
- the query executed in `TileRequestHandler.getPixels` is updated to retrieve the additional columns required for the `ZarrPixelsService` checks i.e. the image externalInfo as well as its format
- `internal-ome.api.IQuery` is set to the `NoopQueryImpl` implemented in `omero-ms-core 0.9.0`
- the `org.apache.httpcomponent` libraries including `httpclient` are unexcluded. Without this change, when accessing OME-Zarr on S3, the `AmazonS3Client` constructor would throw an `java.lang.NoClassDefFoundError: org/apache/http/conn/routing/HttpRoutePlanner`

Testing-wise, a good functional workflow is to deploy an OMERO deployment including this version micro-service with QuPath and our [QuPath OMERO.web extension](https://github.com/glencoesoftware/qupath-extension-omero-web) which uses this micro-service for retrieving raw data, in particular for fluorescence data.
- import a fluorescence image saved as OME-Zarr, hosted on AWS S3 - there are a few examples on our public bucket `s3://gs-public-zarr-archive`
- start QuPath and log into OMERO
- open the fluorescence image, the planes should be loaded and render as expected

/cc @erindiel @melissalinkert 
