### PR TITLE
Bump omero-zarr-pixel-buffer to version 0.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.10.0'
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
-    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.6.0'
+    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.6.1'
     implementation 'com.glencoesoftware.omero:omero-ms-core:0.11.0'
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'


### PR DESCRIPTION
This should allow the pixel-buffer micro-service to work natively with OME-Zarr datasets with less than 5 dimensions, OME-Zarr datasets hosted on S3 compatible object stores as well as OME-Zarr datasets with missing chunks on S3.

See the following links for the list of changes:
- https://github.com/glencoesoftware/omero-zarr-pixel-buffer/releases/tag/v0.6.0 
- https://github.com/glencoesoftware/omero-zarr-pixel-buffer/releases/tag/v0.6.1