### PR TITLE
Set java.io.tmpdir to local application directory at startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,9 +94,13 @@ distributions {
 }
 
 applicationDefaultJvmArgs = [
-    "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory"
+    "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory",
+    "-Djava.io.tmpdir=MY_APP_HOME/tmp"
 ]
 
 startScripts {
   classpath = files('$APP_HOME/lib/*')
+  doLast {
+    unixScript.text = unixScript.text.replace("MY_APP_HOME", "'\$APP_HOME'")
+  }
 }


### PR DESCRIPTION
Fixes #30 
See https://github.com/glencoesoftware/omero-ms-image-region/pull/163 and the discussion for the rationale beyond this implementation


To test these changes

- download a new version of `omero-ms-pixel-buffer` with this change included from GitHub actions or build it locally
- start `omero-ms-pixel-buffer` either manually of via systemd
  * check a `tmp` subfolder has been created under the application home at startup
  * check `$APP_HOME/tmp` contains a `vertx-cache-*` folder related to the micro-service initialisation
  * open either an NDPI image via Bio-Formats or a Zarr images via omero-zarr-pixel-buffer
  * check that new folders called `nativelib-loader*` or `jna-*` are created under `$APP_HOME/tmp`
- stop the application
  * observe that the folders under `$APP_HOME/tmp` are deleted